### PR TITLE
[agile quadrotor] update the configuration for quadrotor in gazebo

### DIFF
--- a/robots/agile_multirotor/config/MotorInfo_F35.yaml
+++ b/robots/agile_multirotor/config/MotorInfo_F35.yaml
@@ -26,3 +26,5 @@ motor_info: # TODO: update
                 polynominal2: -0.005535287 # -0.0005535287 # x10
                 polynominal1:  3.491470057 # 0.3491470057 # x10
                 polynominal0:  -18.637065433 # -18.637065433 # x1
+
+        speed_rate: 10.0 # rad/s/N

--- a/robots/agile_multirotor/config/NavigationConfig.yaml
+++ b/robots/agile_multirotor/config/NavigationConfig.yaml
@@ -8,7 +8,7 @@ navigation:
   # Attitude Control Mode: 4
 
 
-  takeoff_height: 0.6 #1.0
+  takeoff_height: 1.0
   outdoor_takeoff_height: 1.5
 
   # teleop operation

--- a/robots/agile_multirotor/urdf/quadrotor.gazebo.xacro
+++ b/robots/agile_multirotor/urdf/quadrotor.gazebo.xacro
@@ -14,6 +14,23 @@
   <gazebo reference="main_body">
     <mu1>0.1</mu1>
     <mu2>0.1</mu2>
+    <material>Gazebo/Red</material>
+  </gazebo>
+
+  <gazebo reference="thrust1">
+    <material>Gazebo/Black</material>
+  </gazebo>
+
+  <gazebo reference="thrust2">
+    <material>Gazebo/Black</material>
+  </gazebo>
+
+  <gazebo reference="thrust3">
+    <material>Gazebo/Black</material>
+  </gazebo>
+
+  <gazebo reference="thrust4">
+    <material>Gazebo/Black</material>
   </gazebo>
 
 </robot>


### PR DESCRIPTION
### What is this

Update the configuration for agile quadrotor in gazebo


### Details
- update the color for different body pary: red for main body and black for propeller.
- modify the propeller rotation speed in gazebo
- increase the takeoff height from 0.6 m to 1.0 m

![Screenshot from 2022-07-20 00-42-29](https://user-images.githubusercontent.com/3666095/179794247-e365576b-6bc8-45c3-a1d5-9519082f42fe.png)



